### PR TITLE
Fix Siena channel matching: strip EEG prefix before comparing names

### DIFF
--- a/src/dataloaders/common/loader.py
+++ b/src/dataloaders/common/loader.py
@@ -152,7 +152,12 @@ def _process_edf(
     ch_names = raw.ch_names
     name_map = {}
     for ch in ch_names:
-        clean = ch.split("-")[0].strip().upper()
+        # Strip reference suffix (e.g. "EEG Fp1-Ref" → "EEG Fp1", "Fp1-REF" → "Fp1")
+        clean = ch.split("-")[0].strip()
+        # Strip dataset prefix (e.g. "EEG Fp1" → "Fp1")
+        if " " in clean:
+            clean = clean.split()[-1]
+        clean = clean.upper()
         # Match to target
         for target in TARGET_CHANNELS:
             if clean == target.upper():


### PR DESCRIPTION
Siena EDF channels are named "EEG Fp1-Ref" etc. The previous code only
stripped the reference suffix (splitting on "-"), leaving "EEG Fp1"
which never matched the bare electrode names like "FP1". All files were
skipped with "only 0 channels matched".

Fix: after splitting on "-", also take the last whitespace-delimited
token so "EEG Fp1" → "Fp1" before the uppercase comparison.

https://claude.ai/code/session_01YLhxT8jGvnVTAjgxB1XZso