### PR TITLE
Add GitHub Actions CI smoke tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,24 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  smoke:
+    name: Pytest CPU smoke
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: pip install -e ".[dev]"
+
+      - name: Test (pytest)
+        run: pytest -v


### PR DESCRIPTION
## Summary
Adds `.github/workflows/ci.yml`: `pip install -e ".[dev]"` + `pytest -v` on push/PR to `main`.

**Depends on:**
- #33 (pyproject.toml with pinned deps) — needed for the install step to work at all.
- #54 (removes orphaned `test_pipeline.py`) — needed for `pytest` collection to be clean.

Please merge #33 and #54 first (or merge all three in that order); this workflow file itself doesn't change once those land, but it won't go green until they're in.

## Test plan
Ran the equivalent locally on top of both other branches — `pip install -e ".[dev]"` then `pytest -v` → 18 passed.

Fixes #34

Made with [Cursor](https://cursor.com)